### PR TITLE
PORTAL-949

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cdc-react",
-  "version": "1.0.0",
+  "name": "@us-gov-cdc/cdc-react",
+  "version": "0.1.0",
   "description": "Library for ReactJS components for the CDC",
   "main": "./dist/cdc-react.umd.js",
   "module": "./dist/cdc-react.es.js",
@@ -18,7 +18,6 @@
   "repository": "git@github.com:CDCgov/cdc-react.git",
   "author": "cfarmer <cfarmer@fearless.tech>",
   "license": "APACHE-2.0",
-  "private": true,
   "devDependencies": {
     "@storybook/addon-essentials": "^7.0.27",
     "@storybook/addon-interactions": "^7.0.27",


### PR DESCRIPTION
Updated package.json to publish this package to the us-gov-cdc NPM org under the 0.1.0 version.  Package can be found here: https://www.npmjs.com/package/@us-gov-cdc/cdc-react