### PR TITLE
Proposed SCSS Styles

### DIFF
--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,0 +1,34 @@
+/* Accessibility Color Variables */
+
+$main-theme: #005eaa;
+$main-theme-dark: #004f8f;
+$main-theme-darker: #004175;
+$main-theme-light: #88c3ea;
+$main-theme-lighter: #c0e9ff;
+
+$gray-dark: #555555;
+$gray-darker: #333333;
+$gray-light: #e0e0e0;
+
+$primary-blue: #196eb3;
+$primary-brown: #705043;
+$primary-cyan: #007b91;
+$primary-green: #497d0c;
+$primary-indigo: #26418f;
+$primary-orange: #bb4d00;
+$primary-pink: #af4448;
+$primary-purple: #712177;
+$primary-slate: #29434e;
+$primary-teal: #00695c;
+
+$tertiary-amber: #ffecb3;
+$tertiary-blue: #c0e9ff;
+$tertiary-brown: #decec6;
+$tertiary-cyan: #cce5e9;
+$tertiary-green: #dcedc8;
+$tertiary-indigo: #dee8ff;
+$tertiary-orange: #ffe97d;
+$tertiary-pink: #ffc2c2;
+$tertiary-purple: #e3d3e4;
+$tertiary-slate: #b6c6d2;
+$tertiary-teal: #ceece7;

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -1,0 +1,3 @@
+$breakpoint-small: 600px; // convert to rem
+$breakpoint-medium: 800px;
+$breakpoint-large: 1000px;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,0 +1,53 @@
+@mixin btn-states($focus-clr, $hover-clr, $active-clr, $disabled-clr...) {
+  &:focus,
+  .focus {
+    background-color: $focus-clr;
+    border-color: $focus-clr;
+  }
+
+  &:hover,
+  .hover {
+    background-color: $hover-clr;
+    border-color: $hover-clr;
+  }
+
+  &:active,
+  .active {
+    background-color: $active-clr;
+    border-color: $active-clr;
+  }
+
+  &.disabled {
+    background-color: $disabled-clr !important;
+    border: solid 0.2rem $disabled-clr !important;
+    border-radius: $border-radius;
+    color: #3e3e3e;
+    pointer-events: none;
+  }
+}
+
+@mixin create-button-color($palette) {
+  @each $color-name, $color-val in $palette {
+    &.#{$color-name} {
+      color: $color-val;
+    }
+  }
+}
+
+@mixin create-btn-color-classes($palette) {
+  @each $color-name, $color-val in $palette {
+    &.#{$color-name} {
+      background-color: $color-val;
+      border: 0.2rem solid $color-val;
+    }
+  }
+}
+
+@mixin create-outline-btn-color-classes($palette) {
+  @each $color, $color-val in $palette {
+    &.#{$color} {
+      color: $color-val;
+      border: 0.2rem solid $color-val;
+    }
+  }
+}

--- a/src/scss/_palettes.scss
+++ b/src/scss/_palettes.scss
@@ -1,0 +1,27 @@
+$base-btn-palette: (
+  "amber": $tertiary-amber,
+  "blue": $primary-blue,
+  "brown": $primary-brown,
+  "cyan": $primary-cyan,
+  "green": $primary-green,
+  "indigo": $primary-indigo,
+  "orange": $primary-orange,
+  "pink": $primary-pink,
+  "purple": $primary-purple,
+  "slate": $primary-slate,
+  "teal": $primary-teal,
+);
+
+$tertiary-btn-palette: (
+  "amber": $tertiary-amber,
+  "blue": $tertiary-blue,
+  "brown": $tertiary-brown,
+  "cyan": $tertiary-cyan,
+  "green": $tertiary-green,
+  "indigo": $tertiary-indigo,
+  "orange": $tertiary-orange,
+  "pink": $tertiary-pink,
+  "purple": $tertiary-purple,
+  "slate": $tertiary-slate,
+  "teal": $tertiary-teal,
+);

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -1,0 +1,20 @@
+$font-size-h1: 2.25rem;
+$font-size-h2: 1.85rem;
+$font-size-h3: 1.6rem;
+$font-size-h4: 1.26rem;
+$font-size-h5: 1.13rem;
+$font-size-h6: 0.95rem;
+
+$font-size-large: $font-size-h5;
+$font-size-base: 1rem;
+$font-size-medium: $font-size-h6;
+$font-size-small: 0.9rem;
+$font-size-xsmall: 0.8rem;
+
+$font-family: "Open Sans", sans-serif;
+
+$font-weight-bold: 800;
+$font-weight-semibold: 600;
+$font-weight-medium: 500;
+$font-weight-regular: 400;
+$font-weight-light: 200;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -1,38 +1,4 @@
-/* Accessibility Color Variables */
-
-$main-theme: #005eaa;
-$main-theme-dark: #004f8f;
-$main-theme-darker: #004175;
-$main-theme-light: #88c3ea;
-$main-theme-lighter: #c0e9ff;
-
-$gray-dark: #555555;
-$gray-darker: #333333;
-$gray-light: #e0e0e0;
-
-$primary-blue: #196eb3;
-$primary-brown: #705043;
-$primary-cyan: #007b91;
-$primary-green: #497d0c;
-$primary-indigo: #26418f;
-$primary-orange: #bb4d00;
-$primary-pink: #af4448;
-$primary-purple: #712177;
-$primary-slate: #29434e;
-$primary-teal: #00695c;
-
-$tertiary-amber: #ffecb3;
-$tertiary-blue: #c0e9ff;
-$tertiary-brown: #decec6;
-$tertiary-cyan: #cce5e9;
-$tertiary-green: #dcedc8;
-$tertiary-indigo: #dee8ff;
-$tertiary-orange: #ffe97d;
-$tertiary-pink: #ffc2c2;
-$tertiary-purple: #e3d3e4;
-$tertiary-slate: #b6c6d2;
-$tertiary-teal: #ceece7;
-
+@import "colors";
 *,
 html,
 body {

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -1,4 +1,8 @@
 @import "colors";
+@import "typography";
+@import "palettes";
+@import "mixins";
+
 *,
 html,
 body {


### PR DESCRIPTION
Introduce SCSS partials to ensure style modularity, consistency, and re-usability.

For font sizes, I opted for descriptive naming rather than functional as the same font-sizes are used in more than one function. Existing CSS Custom Properties work well in conjunction with SCSS and should not require immediate changes for the additions proposed in this PR to work.

Further work includes:
- Extracting explicit Hex colors into reusable variables
- Making use of sizing variables and mixins for:
	- Fonts
		- Size
		- Weight
	- Media queries

Sizes and colors are reused from previous commits and USWDS tokens.