### PR TITLE
Fix SPDX License Error

### DIFF
--- a/packages/cdc-react-icons/package.json
+++ b/packages/cdc-react-icons/package.json
@@ -2,5 +2,5 @@
   "name": "@us-gov-cdc/cdc-react-icons",
   "version": "0.1.0",
   "description": "SVG Icon library for CDC web applications",
-  "license": "APACHE-2.0"
+  "license": "Apache-2.0"
 }

--- a/packages/cdc-react/package.json
+++ b/packages/cdc-react/package.json
@@ -20,7 +20,7 @@
   },
   "repository": "git@github.com:CDCgov/cdc-react.git",
   "author": "cfarmer <cfarmer@fearless.tech>",
-  "license": "APACHE-2.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@storybook/addon-essentials": "^7.0.27",
     "@storybook/addon-interactions": "^7.0.27",


### PR DESCRIPTION
The component and icon packages are throwing an SPDX licensing error when `yarn` is run. The error is caused by the license name being listed in all caps. In order to fix this error, I changed the licensing identifier to meet the identifier format as listed in https://spdx.org/licenses/.