### PR TITLE
Portal 973/sidebar visual updates

### DIFF
--- a/packages/cdc-react/package.json
+++ b/packages/cdc-react/package.json
@@ -32,6 +32,7 @@
     "@storybook/testing-library": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.2.1",

--- a/packages/cdc-react/src/components/Sidebar/Sidebar.scss
+++ b/packages/cdc-react/src/components/Sidebar/Sidebar.scss
@@ -71,7 +71,9 @@
       .chevron-double-left-mobile {
         display: none;
       }
-
+      a {
+        width: auto;
+      }
       .menu {
         display: flex;
       }

--- a/packages/cdc-react/src/components/Sidebar/Sidebar.scss
+++ b/packages/cdc-react/src/components/Sidebar/Sidebar.scss
@@ -12,7 +12,6 @@
     }
 
     .menu-item {
-      flex-grow: 1;
       padding: 0.7rem 0;
       color: #fff;
     }
@@ -46,6 +45,7 @@
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
 
     .chevron-double-left-mobile {
       display: flex;
@@ -66,6 +66,7 @@
     &.sidebar-collapsed {
       width: 4.7rem;
       flex: 0 0;
+      overflow-y: unset;
 
       .chevron-double-left-mobile {
         display: none;

--- a/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.scss
+++ b/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.scss
@@ -5,14 +5,28 @@
     li {
       display: flex;
       align-items: center;
-      padding: 0.94rem 1.4rem;
-      width: 100%;
-      height: 2.95rem;
     }
 
     li:hover {
       background-color: #00407a;
       cursor: pointer;
+    }
+
+    li a {
+      text-decoration: none;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      color: inherit;
+      padding: 0.94rem 1.4rem;
+      font-size: 0.7rem;
+
+      .text {
+        margin-left: 0.7rem;
+        font-style: normal;
+        font-weight: 100;
+        font-size: 0.7rem;
+      }
     }
 
     .heading {
@@ -25,14 +39,6 @@
       text-transform: uppercase;
       padding: 0.47rem 1.475rem;
       color: $main-theme-lighter;
-    }
-
-    .text {
-      margin-left: 0.7rem;
-      font-style: normal;
-      font-weight: 100;
-      line-height: 120%;
-      font-size: 0.7rem;
     }
   }
 

--- a/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.test.tsx
+++ b/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach } from "vitest";
+import { SidebarSection } from "./SidebarSection";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Sidebar section component", () => {
+  it("should work with keyboard allowing sequential tabbing", async () => {
+    render(
+      <SidebarSection
+        heading="test"
+        items={[
+          { icon: "dashboard", text: "Dashboard" },
+          { icon: "process", text: "Process Status" },
+          { icon: "quality", text: "Quality" },
+        ]}
+      />
+    );
+
+    const anchorElements = screen.getAllByRole("link");
+
+    await userEvent.tab();
+    expect(document.activeElement).toEqual(anchorElements[0]);
+
+    await userEvent.tab();
+    expect(document.activeElement).toEqual(anchorElements[1]);
+
+    await userEvent.tab();
+    expect(document.activeElement).toEqual(anchorElements[2]);
+  });
+});

--- a/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
+++ b/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
@@ -23,8 +23,10 @@ export const SidebarSection = ({
       <ul>
         {items.map((item, index) => (
           <li key={`${item.text}${index}`}>
-            <Icon className={`${item.icon}-icon icon`} name={item.icon} />
-            {!hideLabels && <span className="text">{item.text}</span>}
+            <a href="">
+              <Icon className={`${item.icon}-icon icon`} name={item.icon} />
+              {!hideLabels && <span className="text">{item.text}</span>}
+            </a>
           </li>
         ))}
       </ul>

--- a/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
+++ b/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
@@ -22,7 +22,7 @@ export const SidebarSection = ({
       {heading && !hideLabels && <p className="heading">{heading}</p>}
       <ul>
         {items.map((item, index) => (
-          <li key={`${item.text}${index}`} role="button">
+          <li key={`${item.text}${index}`}>
             <Icon className={`${item.icon}-icon icon`} name={item.icon} />
             {!hideLabels && <span className="text">{item.text}</span>}
           </li>

--- a/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
+++ b/packages/cdc-react/src/components/Sidebar/SidebarSection/SidebarSection.tsx
@@ -23,7 +23,7 @@ export const SidebarSection = ({
       <ul>
         {items.map((item, index) => (
           <li key={`${item.text}${index}`}>
-            <a href="">
+            <a href="/">
               <Icon className={`${item.icon}-icon icon`} name={item.icon} />
               {!hideLabels && <span className="text">{item.text}</span>}
             </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2642,7 +2642,7 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@^14.0.0":
+"@testing-library/user-event@^14.0.0", "@testing-library/user-event@^14.4.3":
   version "14.4.3"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
   integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==


### PR DESCRIPTION
The changes in this PR include adding an anchor tag to the menu items along with corresponding style changes to the sidebar component to allow the user to utilize keyboard tabbing to navigate the navigation.

Considerations:
- The anchor tag currently points to nothing as the pages have not been developed. 
- The updates focus solely on stylistic and accessibility changes and not inherent functional changes.


Note on Keyboard Usage:
- The keyboard tabbing functionality is not fully functional out of the box when using Safari and Firefox on Mac OS. Enabling full keyboard functionality may be necessary. More information may be found here: [The A11Y Collective: How to activate keyboard navigation on MacOS](https://www.a11y-collective.com/how-to-activate-keyboard-navigation-on-macos/).