### PR TITLE
PORTAL-998/Create Init Card Component

### DIFF
--- a/packages/cdc-react/src/components/Card/Card.scss
+++ b/packages/cdc-react/src/components/Card/Card.scss
@@ -1,0 +1,76 @@
+@import "../../scss/global.scss";
+
+.card-wrapper {
+  border-radius: 0.4rem;
+  border: 0.1rem solid $gray-light;
+  overflow: hidden;
+  font-family: $font-family;
+  color: #1b1b1b;
+
+  .card-content {
+    border-top: 0.3rem solid $main-theme;
+    font-family: $font-family;
+
+    .card-header {
+      background: $main-theme-lighter;
+      padding: 0.47059rem 1.05882rem;
+      font-size: $font-size-h4;
+      font-style: normal;
+      font-weight: $font-weight-medium;
+      line-height: 120%;
+    }
+    .card-body {
+      font-style: normal;
+      font-weight: $font-weight-regular;
+
+      .card-section-title {
+        padding: 1.41rem 1.41rem 0.47rem 1.41rem;
+        font-size: $font-size-h5;
+        line-height: 120%;
+        font-weight: $font-weight-regular;
+      }
+      .card-section-media {
+        padding: 0rem 1.41rem 1.41rem 1.41rem;
+      }
+      .card-section-media.media-fill {
+        padding: 0;
+      }
+      .card-section-text {
+        padding: 0.47rem 1.41rem;
+        margin-bottom: 1.41rem;
+        span {
+          font-size: $font-size-base;
+          font-weight: $font-weight-regular;
+          line-height: 120%;
+        }
+      }
+      .card-section-footer {
+        padding: 0.47rem 1.41rem 1.41rem 1.41rem;
+      }
+    }
+    .card-body.horizontal {
+      display: flex;
+      flex-direction: column;
+      .card-section-media,
+      .card-body-content {
+        width: 100%;
+      }
+    }
+    .card-body.vertical-left {
+      display: flex;
+      flex-direction: row;
+      .card-section-media,
+      .card-body-content {
+        flex: 1;
+      }
+    }
+    .card-body.vertical-right {
+      display: flex;
+      flex-direction: row-reverse;
+      .card-section-media,
+      .card-body-content {
+        flex: 1;
+      }
+    }
+  }
+}

--- a/packages/cdc-react/src/components/Card/Card.test.tsx
+++ b/packages/cdc-react/src/components/Card/Card.test.tsx
@@ -1,0 +1,13 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach } from "vitest";
+import { Card } from "./Card";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Card component", () => {
+  it("should render the card component", () => {
+    render(<Card cardLayout="horizontal" cardAction="test" />);
+  });
+});

--- a/packages/cdc-react/src/components/Card/Card.tsx
+++ b/packages/cdc-react/src/components/Card/Card.tsx
@@ -1,0 +1,50 @@
+import { Button } from "../Button/Button";
+import "./Card.scss";
+
+interface CardProps {
+  cardLayout: "horizontal" | "vertical-left" | "vertical-right";
+  showTitleTop?: boolean; // only works for horizontal layout
+  cardSectionText?: string;
+  cardAction: string; // cannot be optional according to the design system
+  cardMediaSource?: string;
+  cardHeader?: string;
+  cardSectionTitle?: string;
+}
+
+export const Card = (props: CardProps) => {
+  return (
+    <div className="card-wrapper">
+      <div className="card-content">
+        {props.cardHeader && (
+          <div className="card-header">{props.cardHeader}</div>
+        )}
+        <div className={`card-body ${props.cardLayout}`}>
+          {props.cardLayout === "horizontal" && props.showTitleTop && (
+            <div className="card-section-title">{props.cardSectionTitle}</div>
+          )}
+
+          <div
+            className={`card-section-media ${
+              props.showTitleTop ? "" : "media-fill"
+            }`}>
+            {props.cardMediaSource && (
+              <img src={props.cardMediaSource} alt={props.cardSectionTitle} />
+            )}
+          </div>
+
+          <div className="card-body-content">
+            {!props.showTitleTop && (
+              <div className="card-section-title">{props.cardSectionTitle}</div>
+            )}
+            <div className="card-section-text">
+              <span>{props.cardSectionText}</span>
+            </div>
+            <div className="card-section-footer">
+              <Button ariaLabel="action">Action</Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR introduces the initial version of the card component to the cdc-react library. 

There are 2 main visual layouts to this component, a horizontal view and a vertical view.