### PR TITLE
Portal 965/cdc react cd

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@cdcgov/cdc-coe-reengineering

--- a/.github/workflows/publish_cdc_react.yml
+++ b/.github/workflows/publish_cdc_react.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Publish to NPM
         run: yarn npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CDC_REACT_NPM_TOKEN }}

--- a/.github/workflows/publish_cdc_react.yml
+++ b/.github/workflows/publish_cdc_react.yml
@@ -1,0 +1,23 @@
+name: "Publish CDC React Components to NPM"
+
+on:
+  push:
+    tags:
+      - cdc-react_*
+
+defaults:
+  run:
+    working-directory: packages/cdc-react
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set release version
+        run: |
+          tag=${GITHUB_REF#refs/*/}
+          OLDIFS="$IFS"
+          IFS='_' tokens=( $tag )
+          echo "RELEASE_VERSION=${tokens[1]}" >> $GITHUB_ENV
+          IFS="$OLDIFS"

--- a/.github/workflows/publish_cdc_react.yml
+++ b/.github/workflows/publish_cdc_react.yml
@@ -18,16 +18,7 @@ jobs:
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org" # Allows NPM credentials to properly be configured.
-      - name: Set release version
-        run: |
-          tag=${GITHUB_REF#refs/*/}
-          OLDIFS="$IFS"
-          IFS='_' tokens=( $tag )
-          echo "RELEASE_VERSION=${tokens[1]}" >> $GITHUB_ENV
-          IFS="$OLDIFS"
-      - name: Update package.json
-        run: yarn version --no-git-tag-version --new-version ${{ env.RELEASE_VERSION }}
-      - name: Install prod-only dependencies
+      - name: Install prod dependencies  
         run: yarn install --production
       - name: Build package
         run: yarn build
@@ -35,5 +26,3 @@ jobs:
         run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Push new version
-      - name: Create Github Release

--- a/.github/workflows/publish_cdc_react.yml
+++ b/.github/workflows/publish_cdc_react.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org" # Allows NPM credentials to properly be configured.
       - name: Set release version
         run: |
           tag=${GITHUB_REF#refs/*/}
@@ -21,3 +25,15 @@ jobs:
           IFS='_' tokens=( $tag )
           echo "RELEASE_VERSION=${tokens[1]}" >> $GITHUB_ENV
           IFS="$OLDIFS"
+      - name: Update package.json
+        run: yarn version --no-git-tag-version --new-version ${{ env.RELEASE_VERSION }}
+      - name: Install prod-only dependencies
+        run: yarn install --production
+      - name: Build package
+        run: yarn build
+      - name: Publish to NPM
+        run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Push new version
+      - name: Create Github Release

--- a/.github/workflows/release_cdc_react.yml
+++ b/.github/workflows/release_cdc_react.yml
@@ -1,0 +1,24 @@
+name: "Release CDC React Library"
+
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - packages/cdc-react/**
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with: 
+          release-type: node
+          package-name: cdc-react
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: packages/cdc-react
+          monorepo-tags: true


### PR DESCRIPTION
Github action workflows for automating the release and publish process for the cdc-react package.  Leverages the please-release custom github action from Google.

Also adds a codeowners file so PRs can be gated by specific contributors.