### PR TITLE
Portal 1050/storybook prop controls

### DIFF
--- a/packages/cdc-react-icons/src/components/ChevronDoubleRight.tsx
+++ b/packages/cdc-react-icons/src/components/ChevronDoubleRight.tsx
@@ -4,13 +4,13 @@ export const ChevronDoubleRight = ({ className }: IconProps) => {
   return (
     <svg
       className={className}
-      xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      fill="none">
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg">
       <path
-        d="M7 11L12 6L7 1M1 11L6 6L1 1"
+        d="M13 17L18 12L13 7M7 17L12 12L7 7"
         stroke="currentColor"
         strokeLinecap="round"
       />

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from "@storybook/react";
 
 import "../src/stories/storybook.css";
-import "@us-gov-cdc/cdc-react/dist/style.css";
+// import "@us-gov-cdc/cdc-react/dist/style.css";
 
 const preview: Preview = {
   parameters: {

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,7 +1,6 @@
 import type { Preview } from "@storybook/react";
 
 import "../src/stories/storybook.css";
-// import "@us-gov-cdc/cdc-react/dist/style.css";
 
 const preview: Preview = {
   parameters: {

--- a/packages/storybook/vite.config.js
+++ b/packages/storybook/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import path from "node:path";
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@us-gov-cdc/cdc-react': path.resolve(__dirname, '../cdc-react/src/components/index.ts'),
+      '@us-gov-cdc/cdc-react-icons': path.resolve(__dirname, '../cdc-react-icons/src/components/index.ts')
+    }
+  }
+});
+


### PR DESCRIPTION
Uses path aliases to resolve component imports, as opposed to importing from node_modules package.