### PR TITLE
Release cdc-react-icons 1.0.8

### DIFF
--- a/packages/cdc-react-icons/package.json
+++ b/packages/cdc-react-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@us-gov-cdc/cdc-react-icons",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "SVG Icon library for CDC web applications",
   "license": "Apache-2.0",
   "repository": "git@github.com:CDCgov/cdc-react.git",


### PR DESCRIPTION
Fixes chevron double right icon position.