### PR TITLE
fix: remove btn-wrap class

### DIFF
--- a/packages/cdc-react/src/components/Button/Button.scss
+++ b/packages/cdc-react/src/components/Button/Button.scss
@@ -2,6 +2,8 @@
 
 .cdc-react.btn {
   display: flex;
+  width: auto;
+  height: auto;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/packages/cdc-react/src/scss/global.scss
+++ b/packages/cdc-react/src/scss/global.scss
@@ -49,11 +49,3 @@ h5 {
     overflow: hidden;
   }
 }
-
-.cdc-react.btn-wrap {
-  min-width: 2.58824rem;
-  min-height: 2.58824rem;
-  width: auto;
-  height: auto;
-  display: inline-block;
-}


### PR DESCRIPTION
Removes `btn-wrap` class and the pesky `display: inline-block` style that was causing the icon to be positioned incorrectly.