### PR TITLE
feat: add autodocs to stories

### DIFF
--- a/packages/storybook/src/stories/Button.stories.tsx
+++ b/packages/storybook/src/stories/Button.stories.tsx
@@ -11,6 +11,7 @@ import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
 const meta: Meta<typeof Button> = {
   title: "Components/Button",
+  tags: ['autodocs'],
   component: Button,
   parameters: {
     backgrounds: {

--- a/packages/storybook/src/stories/Card.stories.tsx
+++ b/packages/storybook/src/stories/Card.stories.tsx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 
 const meta: Meta<typeof Card> = {
   title: "Components/Card",
+  tags: ['autodocs'],
   component: Card,
   argTypes: { actionButtonOnClick: { action: "clicked" } },
 };

--- a/packages/storybook/src/stories/Divider.stories.tsx
+++ b/packages/storybook/src/stories/Divider.stories.tsx
@@ -3,6 +3,7 @@ import { Divider } from "@us-gov-cdc/cdc-react";
 
 const meta: Meta<typeof Divider> = {
   title: "Components/Divider",
+  tags: ['autodocs'],
   component: Divider,
   argTypes: {},
 };

--- a/packages/storybook/src/stories/Icon.stories.tsx
+++ b/packages/storybook/src/stories/Icon.stories.tsx
@@ -3,6 +3,7 @@ import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
 const meta: Meta = {
   title: "Components/Icon",
+  tags: ['autodocs'],
   parameters: {
     backgrounds: {
       default: "default",

--- a/packages/storybook/src/stories/ProfileHeader.stories.tsx
+++ b/packages/storybook/src/stories/ProfileHeader.stories.tsx
@@ -5,6 +5,7 @@ import { Icons } from "@us-gov-cdc/cdc-react-icons";
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta: Meta<typeof ProfileHeader> = {
   title: "Components/ProfileHeader",
+  tags: ['autodocs'],
   component: ProfileHeader,
   argTypes: {},
 };

--- a/packages/storybook/src/stories/Sidebar.stories.tsx
+++ b/packages/storybook/src/stories/Sidebar.stories.tsx
@@ -4,6 +4,7 @@ import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
 const meta: Meta<typeof Sidebar> = {
   title: "Components/Sidebar",
+  tags: ['autodocs'],
   component: Sidebar,
   argTypes: {},
   decorators: [(Story) => <Story />],


### PR DESCRIPTION
This PR introduces the use of [Storybook autodocs](https://storybook.js.org/docs/react/writing-docs/autodocs) into individual stories to help automate documentation for the components.