### PR TITLE
Portal 1070: Allow Icons on Both Sides of Button Text

### DIFF
--- a/packages/cdc-react/src/@types/index.ts
+++ b/packages/cdc-react/src/@types/index.ts
@@ -48,7 +48,7 @@ const ButtonStates = [
 
 export type ButtonStateTypes = (typeof ButtonStates)[number];
 
-const ButtonIconPositions = ["left", "right"] as const;
+const ButtonIconPositions = ["left", "right", "both"] as const;
 
 export type ButtonIconPositionTypes = (typeof ButtonIconPositions)[number];
 

--- a/packages/cdc-react/src/components/Button/Button.test.tsx
+++ b/packages/cdc-react/src/components/Button/Button.test.tsx
@@ -75,4 +75,71 @@ describe("Button component", () => {
     expect(btn).toBeInTheDocument();
     expect(btnAriaLabel).toEqual(ariaLabel);
   });
+
+  describe("Display Button Icons", () => {
+    it("should show icon to the left of the button text", () => {
+      const TestButtonComponent = (
+        <Button
+          ariaLabel="test button"
+          icon={<Icons.BarGraph />}
+          iconPosition="left">
+          <span>Data</span>
+        </Button>
+      );
+
+      const { getByText, container } = render(TestButtonComponent);
+
+      const btnText = getByText("Data");
+      const btnIcon = container.querySelector("svg")!;
+      const textPrevSibling = btnText.previousSibling;
+
+      expect(btnText).toBeInTheDocument();
+      expect(btnIcon).toBeInTheDocument();
+      expect(textPrevSibling).toEqual(btnIcon);
+    });
+
+    it("should show icon to the right of the button text", () => {
+      const TestButtonComponent = (
+        <Button
+          ariaLabel="test button"
+          icon={<Icons.BarGraph />}
+          iconPosition="right">
+          <span>Data</span>
+        </Button>
+      );
+
+      const { getByText, container } = render(TestButtonComponent);
+
+      const btnText = getByText("Data");
+      const btnIcon = container.querySelector("svg")!;
+      const textNextSibling = btnText.nextSibling;
+
+      expect(btnText).toBeInTheDocument();
+      expect(btnIcon).toBeInTheDocument();
+      expect(textNextSibling).toEqual(btnIcon);
+    });
+
+    it("should show icons on both sides of the button text", () => {
+      const TestButtonComponent = (
+        <Button
+          ariaLabel="test button"
+          icon={<Icons.BarGraph />}
+          iconPosition="both">
+          <span>Data</span>
+        </Button>
+      );
+
+      const { getByText, container } = render(TestButtonComponent);
+
+      const btnText = getByText("Data");
+      const btnIcon = container.querySelector("svg")!;
+      const textPrevSibling = btnText.previousSibling!;
+      const textNextSibling = btnText.nextSibling!;
+
+      expect(btnText).toBeInTheDocument();
+      expect(btnIcon).toBeInTheDocument();
+      expect(textPrevSibling).toEqual(btnIcon);
+      expect(textNextSibling).toEqual(btnIcon);
+    });
+  });
 });

--- a/packages/cdc-react/src/components/Button/Button.test.tsx
+++ b/packages/cdc-react/src/components/Button/Button.test.tsx
@@ -90,7 +90,7 @@ describe("Button component", () => {
       const { getByText, container } = render(TestButtonComponent);
 
       const btnText = getByText("Data");
-      const btnIcon = container.querySelector("svg")!;
+      const btnIcon = container.querySelector("svg");
       const textPrevSibling = btnText.previousSibling;
 
       expect(btnText).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe("Button component", () => {
       const { getByText, container } = render(TestButtonComponent);
 
       const btnText = getByText("Data");
-      const btnIcon = container.querySelector("svg")!;
+      const btnIcon = container.querySelector("svg");
       const textNextSibling = btnText.nextSibling;
 
       expect(btnText).toBeInTheDocument();
@@ -132,7 +132,7 @@ describe("Button component", () => {
       const { getByText, container } = render(TestButtonComponent);
 
       const btnText = getByText("Data");
-      const btnIcon = container.querySelector("svg")!;
+      const btnIcon = container.querySelector("svg");
       const textPrevSibling = btnText.previousSibling!;
       const textNextSibling = btnText.nextSibling!;
 

--- a/packages/cdc-react/src/components/Button/Button.tsx
+++ b/packages/cdc-react/src/components/Button/Button.tsx
@@ -106,9 +106,9 @@ export const Button = ({
       id={id}
       className={classes}
       disabled={disabled}>
-      {icon && iconPosition === "left" && icon}
+      {icon && (iconPosition === "left" || iconPosition === "both") && icon}
       {iconOnly !== true ? children : icon}
-      {icon && iconPosition === "right" && icon}
+      {icon && (iconPosition === "right" || iconPosition === "both") && icon}
     </button>
   );
 };

--- a/packages/storybook/src/stories/Button.stories.tsx
+++ b/packages/storybook/src/stories/Button.stories.tsx
@@ -11,7 +11,7 @@ import { Icons } from "@us-gov-cdc/cdc-react-icons";
 
 const meta: Meta<typeof Button> = {
   title: "Components/Button",
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   component: Button,
   parameters: {
     backgrounds: {
@@ -116,6 +116,14 @@ export const iconButtons: Story = {
           icon={<Icons.Process />}
           iconPosition="right">
           <span>Process</span>
+        </Button>
+        <h5>Icon Both Sides Button:</h5>
+        <Button
+          ariaLabel={ariaLabel}
+          size={size}
+          icon={<Icons.Menu />}
+          iconPosition="both">
+          <span>Menu</span>
         </Button>
       </>
     );


### PR DESCRIPTION
This PR introduces the ability for a user to specify if they want icons on both sides of the text inside the button.

- Modifies the button component props to allow for one more setting.
- Adds unit tests for the position of the icons relative to button text.