### PR TITLE
Portal 1127/create modal component

### DIFF
--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -13,91 +13,77 @@
   align-items: center;
   backdrop-filter: blur(5px);
 }
+
 .modal {
-  border-radius: 0.23529rem;
-  border: 1px solid var(--system-gray-gray-light, #e0e0e0);
-  background: var(--system-gray-white, #fff);
+  border-radius: 0.236rem;
+  border: 1px solid global.$gray-light;
+  background: #fff;
+
   .modal-content {
     position: relative;
+
     .modal-main {
       .modal-header {
         display: flex;
-        padding: 0.70588rem 1.41176rem;
+        padding: units(1.5) units(3);
         align-items: flex-start;
-        gap: 0.70588rem;
         display: flex;
         justify-content: space-between;
-        border-bottom: 1px solid var(--system-gray-gray-light, #e0e0e0);
+        border-bottom: 1px solid global.$gray-light;
+
         .modal-title {
           margin: 0;
           color: global.$gray-darker;
-          font-size: 1.26rem;
+          font-size: global.$font-size-h4;
           font-style: normal;
-          font-weight: 500;
+          font-weight: global.$font-weight-medium;
           line-height: 120%;
         }
       }
+
       .modal-body {
+        font-family: global.$font-family;
+        font-size: global.$font-size-small;
+        font-weight: global.$font-weight-regular;
         display: flex;
-        padding: 1.41176rem;
+        padding: units(3);
         flex-direction: column;
-        align-items: flex-start;
-        gap: 1.41176rem;
-        align-self: stretch;
+        line-height: 140%;
       }
+
       .modal-footer {
+        font-weight: global.$font-weight-regular;
         margin-top: 10px;
-        border-top: 1px solid var(--system-gray-gray-light, #e0e0e0);
+        border-top: 1px solid global.$gray-light;
         display: flex;
-        padding: 0.70588rem 1.41176rem;
+        padding: units(1.5) units(3);
         justify-content: flex-end;
         align-items: flex-start;
-        gap: 0.70588rem;
+        gap: units(1.5);
         align-self: stretch;
+
+        button {
+          font-weight: global.$font-weight-regular;
+        }
       }
     }
+
     .modal-close-btn {
       position: absolute;
       top: 2.5rem;
-      right: 1.41rem;
+      right: 0.71rem;
     }
   }
 }
 
-.wrapper {
-  width: 320px;
-  border: 1px solid #ccc;
-  padding: 20px;
-  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.container {
-  width: 100%;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-}
-.title {
-  margin: 0;
-}
-
-.body {
-  margin: 10px 0;
-}
-
-.footer {
-  margin-top: 10px;
-}
-
 ul,
 li {
-  font-size: 0.9rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 140%;
+  list-style-type: initial;
+  font-family: global.$font-family;
+  font-size: global.$font-size-small;
+  font-weight: global.$font-weight-regular;
 }
+
 .usa-modal__content {
   position: relative;
   padding-top: 0 !important;

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -18,8 +18,14 @@
   position: relative;
   width: 320px;
   border: 1px solid #ccc;
-  padding: 20px;
+  // padding: 20px;
   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
+  &.default {
+    background-color: red;
+  }
+  &.large {
+    background-color: blue;
+  }
   .modal-content {
     .modal-main {
       .modal-header {
@@ -27,7 +33,6 @@
         padding: 0.70588rem 1.41176rem;
         align-items: flex-start;
         gap: 0.70588rem;
-        background-color: red;
         display: flex;
         justify-content: space-between;
         .modal-title {
@@ -84,7 +89,7 @@
 .header {
   display: flex;
   justify-content: space-between;
-
+}
 .title {
   margin: 0;
 }

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -53,7 +53,7 @@
 
       .modal-footer {
         font-weight: global.$font-weight-regular;
-        margin-top: 10px;
+        margin-top: units(1);
         border-top: 1px solid global.$gray-light;
         display: flex;
         padding: units(1.5) units(3);

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -65,7 +65,6 @@
 }
 
 .wrapper {
-  // position: relative;
   width: 320px;
   border: 1px solid #ccc;
   padding: 20px;

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -1,2 +1,15 @@
 @use "../../scss/global.scss";
 @use "uswds-core" as *;
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(global.$gray-darker, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backdrop-filter: blur(5px);
+}

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -14,19 +14,11 @@
   backdrop-filter: blur(5px);
 }
 .modal {
-  background-color: pink;
-  position: relative;
-  width: 320px;
-  border: 1px solid #ccc;
-  // padding: 20px;
-  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
-  &.default {
-    background-color: red;
-  }
-  &.large {
-    background-color: blue;
-  }
+  border-radius: 0.23529rem;
+  border: 1px solid var(--system-gray-gray-light, #e0e0e0);
+  background: var(--system-gray-white, #fff);
   .modal-content {
+    position: relative;
     .modal-main {
       .modal-header {
         display: flex;
@@ -35,6 +27,7 @@
         gap: 0.70588rem;
         display: flex;
         justify-content: space-between;
+        border-bottom: 1px solid var(--system-gray-gray-light, #e0e0e0);
         .modal-title {
           margin: 0;
           color: global.$gray-darker;
@@ -45,7 +38,6 @@
         }
       }
       .modal-body {
-        margin: 10px 0;
         display: flex;
         padding: 1.41176rem;
         flex-direction: column;
@@ -55,27 +47,25 @@
       }
       .modal-footer {
         margin-top: 10px;
+        border-top: 1px solid var(--system-gray-gray-light, #e0e0e0);
+        display: flex;
+        padding: 0.70588rem 1.41176rem;
+        justify-content: flex-end;
+        align-items: flex-start;
+        gap: 0.70588rem;
+        align-self: stretch;
       }
     }
     .modal-close-btn {
-      background-color: #f44336;
-      color: #fff;
-      border: none;
-      border-radius: 50%;
-      width: 25px;
-      height: 25px;
-      line-height: 25px;
-      text-align: center;
-      cursor: pointer;
       position: absolute;
-      top: 10px;
-      right: 10px;
+      top: 2.5rem;
+      right: 1.41rem;
     }
   }
 }
 
 .wrapper {
-  position: relative;
+  // position: relative;
   width: 320px;
   border: 1px solid #ccc;
   padding: 20px;
@@ -102,17 +92,14 @@
   margin-top: 10px;
 }
 
-.close-btn {
-  background-color: #f44336;
-  color: #fff;
-  border: none;
-  border-radius: 50%;
-  width: 25px;
-  height: 25px;
-  line-height: 25px;
-  text-align: center;
-  cursor: pointer;
-  position: absolute;
-  top: 10px;
-  right: 10px;
+ul,
+li {
+  font-size: 0.9rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 140%;
+}
+.usa-modal__content {
+  position: relative;
+  padding-top: 0 !important;
 }

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -1,0 +1,2 @@
+@use "../../scss/global.scss";
+@use "uswds-core" as *;

--- a/packages/cdc-react/src/components/Modal/Modal.scss
+++ b/packages/cdc-react/src/components/Modal/Modal.scss
@@ -13,3 +13,101 @@
   align-items: center;
   backdrop-filter: blur(5px);
 }
+.modal {
+  background-color: pink;
+  position: relative;
+  width: 320px;
+  border: 1px solid #ccc;
+  padding: 20px;
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
+  .modal-content {
+    .modal-main {
+      .modal-header {
+        display: flex;
+        padding: 0.70588rem 1.41176rem;
+        align-items: flex-start;
+        gap: 0.70588rem;
+        background-color: red;
+        display: flex;
+        justify-content: space-between;
+        .modal-title {
+          margin: 0;
+          color: global.$gray-darker;
+          font-size: 1.26rem;
+          font-style: normal;
+          font-weight: 500;
+          line-height: 120%;
+        }
+      }
+      .modal-body {
+        margin: 10px 0;
+        display: flex;
+        padding: 1.41176rem;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.41176rem;
+        align-self: stretch;
+      }
+      .modal-footer {
+        margin-top: 10px;
+      }
+    }
+    .modal-close-btn {
+      background-color: #f44336;
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 25px;
+      height: 25px;
+      line-height: 25px;
+      text-align: center;
+      cursor: pointer;
+      position: absolute;
+      top: 10px;
+      right: 10px;
+    }
+  }
+}
+
+.wrapper {
+  position: relative;
+  width: 320px;
+  border: 1px solid #ccc;
+  padding: 20px;
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.container {
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+
+.title {
+  margin: 0;
+}
+
+.body {
+  margin: 10px 0;
+}
+
+.footer {
+  margin-top: 10px;
+}
+
+.close-btn {
+  background-color: #f44336;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  line-height: 25px;
+  text-align: center;
+  cursor: pointer;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}

--- a/packages/cdc-react/src/components/Modal/Modal.test.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.test.tsx
@@ -1,9 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Modal } from "./Modal";
+import { vi } from "vitest";
 
 describe("Modal component", () => {
-  it("should render the modal component", () => {
-    render(<Modal />);
-    expect(screen.getByText("Modal")).toBeInTheDocument();
+  it("should render the modal component with text inside", () => {
+    const { getByText } = render(
+      <Modal isOpen={true} onClose={() => {}}>
+        Modal
+      </Modal>
+    );
+
+    expect(getByText("Modal")).toBeVisible();
+  });
+
+  it("should not render the modal component when isOpen is false", () => {
+    const { queryByText } = render(
+      <Modal isOpen={false} onClose={() => {}}>
+        Modal
+      </Modal>
+    );
+    expect(queryByText("Modal")).toBeNull();
+  });
+
+  it("should call onClose when modal close button is clicked", () => {
+    const onCloseMock = vi.fn();
+
+    const { container } = render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        Modal
+      </Modal>
+    );
+    const closeButton = container.querySelector(".modal-close-btn");
+    if (!closeButton) {
+      throw new Error("button not found");
+    }
+
+    fireEvent.click(closeButton);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cdc-react/src/components/Modal/Modal.test.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+import { Modal } from "./Modal";
+
+describe("Modal component", () => {
+  it("should render the modal component", () => {
+    render(<Modal />);
+    expect(screen.getByText("Modal")).toBeInTheDocument();
+  });
+});

--- a/packages/cdc-react/src/components/Modal/Modal.test.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.test.tsx
@@ -5,7 +5,7 @@ import { vi } from "vitest";
 describe("Modal component", () => {
   it("should render the modal component with text inside", () => {
     const { getByText } = render(
-      <Modal isOpen={true} onClose={() => {}}>
+      <Modal modalTitle="" isOpen={true} onClose={() => {}}>
         Modal
       </Modal>
     );
@@ -15,7 +15,7 @@ describe("Modal component", () => {
 
   it("should not render the modal component when isOpen is false", () => {
     const { queryByText } = render(
-      <Modal isOpen={false} onClose={() => {}}>
+      <Modal modalTitle="" isOpen={false} onClose={() => {}}>
         Modal
       </Modal>
     );
@@ -26,7 +26,7 @@ describe("Modal component", () => {
     const onCloseMock = vi.fn();
 
     const { container } = render(
-      <Modal isOpen={true} onClose={onCloseMock}>
+      <Modal modalTitle="" isOpen={true} onClose={onCloseMock}>
         Modal
       </Modal>
     );
@@ -44,7 +44,7 @@ describe("Modal component", () => {
     const onCloseMock = vi.fn();
 
     const screen = render(
-      <Modal isOpen={true} onClose={onCloseMock}>
+      <Modal modalTitle="" isOpen={true} onClose={onCloseMock}>
         Modal
       </Modal>
     );
@@ -58,7 +58,11 @@ describe("Modal component", () => {
     const onCloseMock = vi.fn();
 
     const screen = render(
-      <Modal isOpen={true} onClose={onCloseMock} isForcedAction={true}>
+      <Modal
+        modalTitle=""
+        isOpen={true}
+        onClose={onCloseMock}
+        isForcedAction={true}>
         Modal
       </Modal>
     );

--- a/packages/cdc-react/src/components/Modal/Modal.test.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.test.tsx
@@ -39,4 +39,32 @@ describe("Modal component", () => {
 
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
+
+  it("should call onClose when presentation overlay is clicked and isForced is false", () => {
+    const onCloseMock = vi.fn();
+
+    const screen = render(
+      <Modal isOpen={true} onClose={onCloseMock}>
+        Modal
+      </Modal>
+    );
+    const presentationOverlay = screen.getByRole("presentation");
+    fireEvent.click(presentationOverlay);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call onClose when presentation overlay is clicked and isForced is true", () => {
+    const onCloseMock = vi.fn();
+
+    const screen = render(
+      <Modal isOpen={true} onClose={onCloseMock} isForcedAction={true}>
+        Modal
+      </Modal>
+    );
+    const presentationOverlay = screen.getByRole("presentation");
+    fireEvent.click(presentationOverlay);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,0 +1,3 @@
+export const Modal = () => {
+  return <>Modal</>;
+};

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import "./Modal.scss";
-import { Button } from "@us-gov-cdc/cdc-react";
+import { Button } from "../Button/Button";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
 import { useRef } from "react";
 export interface ModalProps {

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -22,24 +22,6 @@ export const Modal = (props: ModalProps) => {
   const uswdsSizeClass =
     props.size === "large" ? "usa-modal usa-modal--lg" : "usa-modal";
 
-  // Hook: determine whether to close the modal once overlay is clicked. - Optional
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        !props.isForcedAction &&
-        props.isOpen &&
-        modalRef.current &&
-        !modalRef.current.contains(event.target as Node)
-      ) {
-        props.onClose();
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [props.isOpen, props.isForcedAction, props.onClose]);
-
-  // Event Handler: close the modal if overlay is clicked
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === overlayRef.current && !props.isForcedAction) {
       props.onClose();

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import { useRef } from "react";
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
+  modalTitle: string;
   children?: React.ReactNode;
   isForcedAction?: boolean;
 }
@@ -36,7 +37,12 @@ export const Modal = (props: ModalProps) => {
         role="dialog"
         aria-modal="true">
         <div className="modal-content usa-modal__content">
-          <div className="modal-main">{props.children}</div>
+          <div className="modal-main">
+            <div className="modal-header">
+              <h2 className="modal-title">{props.modalTitle}</h2>
+            </div>
+            {props.children}
+          </div>
           <Button
             ariaLabel="Close this window"
             size="tiny"
@@ -52,14 +58,6 @@ export const Modal = (props: ModalProps) => {
 };
 
 // TODO: extract these components to their own files
-export const ModalTitle = (props: ModalChildrenProps) => {
-  return (
-    <div className="modal-header">
-      <h2 className="modal-title">{props.children}</h2>
-    </div>
-  );
-};
-
 export const ModalBody = (props: ModalChildrenProps) => {
   return <div className="modal-body">{props.children}</div>;
 };

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ export interface ModalProps {
   onClose: () => void;
   children?: React.ReactNode;
   isForcedAction?: boolean;
+  size: "default" | "large";
 }
 export interface ModalChildrenProps {
   children: React.ReactNode;
@@ -47,22 +48,17 @@ export const Modal = (props: ModalProps) => {
       ref={overlayRef}
       onClick={handleOverlayClick}
       role="presentation"
-      className="modal-overlay"
-      style={{}}>
-      <div
-        ref={modalRef}
-        className="modal usa-modal"
-        role="dialog"
-        aria-modal="true">
-        <div className="usa-modal__content">
-          <div className="usa-modal__main">{props.children}</div>
+      className="modal-overlay">
+      <div ref={modalRef} className="modal" role="dialog" aria-modal="true">
+        <div className="modal-content usa-modal__content">
+          <div className="modal-main">{props.children}</div>
           <Button
             ariaLabel="Close this window"
             size="tiny"
             iconOnly={true}
             icon={<Icons.Close />}
             variation="unstyled"
-            className="usa-button usa-modal__close"
+            className="usa-button usa-modal__close modal-close-btn"
             onClick={props.onClose}></Button>
         </div>
       </div>
@@ -72,7 +68,11 @@ export const Modal = (props: ModalProps) => {
 
 // TODO: extract these components to their own files
 export const ModalTitle = (props: ModalChildrenProps) => {
-  return <h2 className="modal-title usa-modal__heading">{props.children}</h2>;
+  return (
+    <div className="modal-header">
+      <h2 className="modal-title">{props.children}</h2>
+    </div>
+  );
 };
 
 export const ModalBody = (props: ModalChildrenProps) => {

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,3 +1,46 @@
-export const Modal = () => {
-  return <>Modal</>;
+import "./Modal.scss";
+import { Button } from "@us-gov-cdc/cdc-react";
+import { Icons } from "@us-gov-cdc/cdc-react-icons";
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  modalTitle?: string;
+  modalBody?: string;
+  modalFooter?: string;
+  isForcedAction?: boolean;
+}
+
+export const Modal = (props: ModalProps) => {
+  return (
+    <div className="modal usa-modal">
+      <div className="usa-modal__content">
+        <div className="usa-modal__main">
+          <h2 className="usa-modal__heading">{props.modalTitle}</h2>
+          <div className="usa-prose">
+            <p>{props.modalBody}</p>
+          </div>
+          <div className="usa-modal__footer">
+            <ul className="usa-button-group">
+              <li className="usa-button-group__item">
+                <Button ariaLabel="continue">Continue without saving</Button>
+              </li>
+              <li className="usa-button-group__item">
+                <Button ariaLabel="go back" variation="text">
+                  Go back
+                </Button>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <Button
+          ariaLabel="Close this window"
+          size="tiny"
+          iconOnly={true}
+          icon={<Icons.Close />}
+          variation="unstyled"
+          className="usa-button usa-modal__close"></Button>
+      </div>
+    </div>
+  );
 };

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -16,7 +16,6 @@ export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
-  // Close modal when clicking outside (optional based on prop)
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
@@ -33,7 +32,6 @@ export const Modal = (props: ModalProps) => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [props.isOpen, props.isForcedAction, props.onClose]);
 
-  // Focus the modal when it opens
   useEffect(() => {
     if (props.isOpen) {
       modalRef.current?.focus();

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -2,20 +2,33 @@ import "./Modal.scss";
 import { Button } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
 import { useEffect, useRef } from "react";
+
+type ModalSize = "default" | "large";
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children?: React.ReactNode;
   isForcedAction?: boolean;
-  size: "default" | "large";
+  size?: ModalSize;
 }
 export interface ModalChildrenProps {
   children: React.ReactNode;
 }
 
+// Mapping the optional modal size choice to the USWDS predefined CSS class
+// The map declaration/definition exists outside of the component const to prevent the map from being rebuilt everytime the component is (re)built
+const propSizeToUSWDSClassMap = {
+  default: "usa-modal",
+  large: "usa-modal--lg",
+};
+
 export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  const uswdsSizeClass = props.size
+    ? propSizeToUSWDSClassMap[props.size]
+    : "usa-modal";
 
   // Hook: determine whether to close the modal once overlay is clicked. - Optional
   useEffect(() => {
@@ -49,17 +62,27 @@ export const Modal = (props: ModalProps) => {
       onClick={handleOverlayClick}
       role="presentation"
       className="modal-overlay">
-      <div ref={modalRef} className="modal" role="dialog" aria-modal="true">
-        <div className="modal-content usa-modal__content">
-          <div className="modal-main">{props.children}</div>
-          <Button
-            ariaLabel="Close this window"
-            size="tiny"
-            iconOnly={true}
-            icon={<Icons.Close />}
-            variation="unstyled"
-            className="usa-button usa-modal__close modal-close-btn"
-            onClick={props.onClose}></Button>
+      <div
+        ref={modalRef}
+        className={`modal ${props.size}`}
+        role="dialog"
+        aria-modal="true">
+        <div
+          ref={modalRef}
+          className={`modal ${uswdsSizeClass}`}
+          role="dialog"
+          aria-modal="true">
+          <div className="modal-content usa-modal__content">
+            <div className="modal-main">{props.children}</div>
+            <Button
+              ariaLabel="Close this window"
+              size="tiny"
+              iconOnly={true}
+              icon={<Icons.Close />}
+              variation="unstyled"
+              className="usa-button usa-modal__close modal-close-btn"
+              onClick={props.onClose}></Button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,10 +1,10 @@
 import "./Modal.scss";
 import { Button } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 export interface ModalProps {
   isOpen: boolean;
-  onClose?: () => void;
+  onClose: () => void;
   children?: React.ReactNode;
   isForcedAction?: boolean;
 }
@@ -13,6 +13,14 @@ export interface ModalChildrenProps {
 }
 
 export const Modal = (props: ModalProps) => {
+  const overlayRef = useRef(null);
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === overlayRef.current) {
+      props.onClose();
+    }
+  };
+
   useEffect(() => {
     if (props.isOpen) {
       document.body.style.overflow = "hidden";
@@ -31,18 +39,14 @@ export const Modal = (props: ModalProps) => {
       setBackgroundColor("rgba(0,0,0,0.5)");
     }
   }, [props.isOpen]);
+
   if (!props.isOpen) return null;
-  useEffect(() => {
-    if (props.isOpen) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "unset";
-    };
-  }, [props.isOpen]);
 
   return (
     <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      role="presentation"
       className="modal-overlay"
       style={{
         position: "fixed",
@@ -54,7 +58,7 @@ export const Modal = (props: ModalProps) => {
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
-        backdropFilter: "blur(5px)", // Blurred background
+        backdropFilter: "blur(5px)",
         backgroundColor,
       }}>
       <div

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -15,20 +15,12 @@ export interface ModalChildrenProps {
   children: React.ReactNode;
 }
 
-// Mapping the optional modal size choice to the USWDS predefined CSS class
-// The map declaration/definition exists outside of the component const to prevent the map from being rebuilt everytime the component is (re)built
-const propSizeToUSWDSClassMap = {
-  default: "usa-modal",
-  large: "usa-modal--lg",
-};
-
 export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
-  const uswdsSizeClass = props.size
-    ? propSizeToUSWDSClassMap[props.size]
-    : "usa-modal";
+  const uswdsSizeClass =
+    props.size === "large" ? "usa-modal usa-modal--lg" : "usa-modal";
 
   // Hook: determine whether to close the modal once overlay is clicked. - Optional
   useEffect(() => {
@@ -64,25 +56,19 @@ export const Modal = (props: ModalProps) => {
       className="modal-overlay">
       <div
         ref={modalRef}
-        className={`modal ${props.size}`}
+        className={`modal ${uswdsSizeClass}`}
         role="dialog"
         aria-modal="true">
-        <div
-          ref={modalRef}
-          className={`modal ${uswdsSizeClass}`}
-          role="dialog"
-          aria-modal="true">
-          <div className="modal-content usa-modal__content">
-            <div className="modal-main">{props.children}</div>
-            <Button
-              ariaLabel="Close this window"
-              size="tiny"
-              iconOnly={true}
-              icon={<Icons.Close />}
-              variation="unstyled"
-              className="usa-button usa-modal__close modal-close-btn"
-              onClick={props.onClose}></Button>
-          </div>
+        <div className="modal-content usa-modal__content">
+          <div className="modal-main">{props.children}</div>
+          <Button
+            ariaLabel="Close this window"
+            size="tiny"
+            iconOnly={true}
+            icon={<Icons.Close />}
+            variation="unstyled"
+            className="usa-button usa-modal__close modal-close-btn"
+            onClick={props.onClose}></Button>
         </div>
       </div>
     </div>

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -56,12 +56,3 @@ export const Modal = (props: ModalProps) => {
     </div>
   );
 };
-
-// TODO: extract these components to their own files
-export const ModalBody = (props: ModalChildrenProps) => {
-  return <div className="modal-body">{props.children}</div>;
-};
-
-export const ModalFooter = (props: ModalChildrenProps) => {
-  return <div className="modal-footer usa-modal__footer">{props.children}</div>;
-};

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,7 +1,7 @@
 import "./Modal.scss";
 import { Button } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -16,13 +16,14 @@ export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
+  // Hook: determine whether to close the modal once overlay is clicked. - Optional
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
         !props.isForcedAction &&
         props.isOpen &&
         modalRef.current &&
-        !modalRef.current.contains(event.target)
+        !modalRef.current.contains(event.target as Node)
       ) {
         props.onClose();
       }
@@ -32,36 +33,12 @@ export const Modal = (props: ModalProps) => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [props.isOpen, props.isForcedAction, props.onClose]);
 
-  useEffect(() => {
-    if (props.isOpen) {
-      modalRef.current?.focus();
-    }
-  }, [props.isOpen]);
-
+  // Event Handler: close the modal if overlay is clicked
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === overlayRef.current && !props.isForcedAction) {
       props.onClose();
     }
   };
-
-  useEffect(() => {
-    if (props.isOpen) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "unset";
-    };
-  }, [props.isOpen]);
-
-  const [backgroundColor, setBackgroundColor] = useState("rgba(0,0,0,0.5)");
-
-  useEffect(() => {
-    if (!props.isOpen) {
-      setBackgroundColor("rgba(255,0,0,0.5)");
-    } else {
-      setBackgroundColor("rgba(0,0,0,0.5)");
-    }
-  }, [props.isOpen]);
 
   if (!props.isOpen) return null;
 
@@ -71,32 +48,12 @@ export const Modal = (props: ModalProps) => {
       onClick={handleOverlayClick}
       role="presentation"
       className="modal-overlay"
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        background: "rgba(255, 105, 180, 0.8)",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        backdropFilter: "blur(5px)",
-        backgroundColor,
-      }}>
+      style={{}}>
       <div
         ref={modalRef}
         className="modal usa-modal"
         role="dialog"
-        aria-modal="true"
-        aria-labelledby="modalTitle"
-        style={{
-          maxWidth: "600px",
-          margin: "100px auto",
-          background: "white",
-          padding: "20px",
-          borderRadius: "5px",
-        }}>
+        aria-modal="true">
         <div className="usa-modal__content">
           <div className="usa-modal__main">{props.children}</div>
           <Button
@@ -113,6 +70,7 @@ export const Modal = (props: ModalProps) => {
   );
 };
 
+// TODO: extract these components to their own files
 export const ModalTitle = (props: ModalChildrenProps) => {
   return <h2 className="modal-title usa-modal__heading">{props.children}</h2>;
 };

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -61,11 +61,7 @@ export const ModalTitle = (props: ModalChildrenProps) => {
 };
 
 export const ModalBody = (props: ModalChildrenProps) => {
-  return (
-    <div className="modal-body usa-prose">
-      <p>{props.children}</p>
-    </div>
-  );
+  return <div className="modal-body">{props.children}</div>;
 };
 
 export const ModalFooter = (props: ModalChildrenProps) => {

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -40,8 +40,9 @@ export const Modal = (props: ModalProps) => {
             </div>
             {props.children}
           </div>
+          {/* The close button is the last element to allow for expected tabbing behavior */}
           <Button
-            ariaLabel="Close this window"
+            ariaLabel="Close modal"
             size="tiny"
             iconOnly={true}
             icon={<Icons.Close />}

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -13,10 +13,35 @@ export interface ModalChildrenProps {
 }
 
 export const Modal = (props: ModalProps) => {
-  const overlayRef = useRef(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Close modal when clicking outside (optional based on prop)
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        !props.isForcedAction &&
+        props.isOpen &&
+        modalRef.current &&
+        !modalRef.current.contains(event.target)
+      ) {
+        props.onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [props.isOpen, props.isForcedAction, props.onClose]);
+
+  // Focus the modal when it opens
+  useEffect(() => {
+    if (props.isOpen) {
+      modalRef.current?.focus();
+    }
+  }, [props.isOpen]);
 
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === overlayRef.current) {
+    if (event.target === overlayRef.current && !props.isForcedAction) {
       props.onClose();
     }
   };
@@ -62,7 +87,11 @@ export const Modal = (props: ModalProps) => {
         backgroundColor,
       }}>
       <div
+        ref={modalRef}
         className="modal usa-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modalTitle"
         style={{
           maxWidth: "600px",
           margin: "100px auto",

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -9,9 +9,6 @@ export interface ModalProps {
   children?: React.ReactNode;
   isForcedAction?: boolean;
 }
-// export interface ModalChildrenProps {
-//   children: React.ReactNode;
-// }
 
 export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -9,9 +9,9 @@ export interface ModalProps {
   children?: React.ReactNode;
   isForcedAction?: boolean;
 }
-export interface ModalChildrenProps {
-  children: React.ReactNode;
-}
+// export interface ModalChildrenProps {
+//   children: React.ReactNode;
+// }
 
 export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,15 +1,12 @@
 import "./Modal.scss";
 import { Button } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
-import { useEffect, useRef } from "react";
-
-type ModalSize = "default" | "large";
+import { useRef } from "react";
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children?: React.ReactNode;
   isForcedAction?: boolean;
-  size?: ModalSize;
 }
 export interface ModalChildrenProps {
   children: React.ReactNode;
@@ -18,9 +15,6 @@ export interface ModalChildrenProps {
 export const Modal = (props: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
-
-  const uswdsSizeClass =
-    props.size === "large" ? "usa-modal usa-modal--lg" : "usa-modal";
 
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === overlayRef.current && !props.isForcedAction) {
@@ -38,7 +32,7 @@ export const Modal = (props: ModalProps) => {
       className="modal-overlay">
       <div
         ref={modalRef}
-        className={`modal ${uswdsSizeClass}`}
+        className="modal usa-modal"
         role="dialog"
         aria-modal="true">
         <div className="modal-content usa-modal__content">

--- a/packages/cdc-react/src/components/Modal/Modal.tsx
+++ b/packages/cdc-react/src/components/Modal/Modal.tsx
@@ -1,46 +1,99 @@
 import "./Modal.scss";
 import { Button } from "@us-gov-cdc/cdc-react";
 import { Icons } from "@us-gov-cdc/cdc-react-icons";
+import { useEffect, useState } from "react";
 export interface ModalProps {
   isOpen: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-  modalTitle?: string;
-  modalBody?: string;
-  modalFooter?: string;
+  onClose?: () => void;
+  children?: React.ReactNode;
   isForcedAction?: boolean;
+}
+export interface ModalChildrenProps {
+  children: React.ReactNode;
 }
 
 export const Modal = (props: ModalProps) => {
+  useEffect(() => {
+    if (props.isOpen) {
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [props.isOpen]);
+
+  const [backgroundColor, setBackgroundColor] = useState("rgba(0,0,0,0.5)");
+
+  useEffect(() => {
+    if (!props.isOpen) {
+      setBackgroundColor("rgba(255,0,0,0.5)");
+    } else {
+      setBackgroundColor("rgba(0,0,0,0.5)");
+    }
+  }, [props.isOpen]);
+  if (!props.isOpen) return null;
+  useEffect(() => {
+    if (props.isOpen) {
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [props.isOpen]);
+
   return (
-    <div className="modal usa-modal">
-      <div className="usa-modal__content">
-        <div className="usa-modal__main">
-          <h2 className="usa-modal__heading">{props.modalTitle}</h2>
-          <div className="usa-prose">
-            <p>{props.modalBody}</p>
-          </div>
-          <div className="usa-modal__footer">
-            <ul className="usa-button-group">
-              <li className="usa-button-group__item">
-                <Button ariaLabel="continue">Continue without saving</Button>
-              </li>
-              <li className="usa-button-group__item">
-                <Button ariaLabel="go back" variation="text">
-                  Go back
-                </Button>
-              </li>
-            </ul>
-          </div>
+    <div
+      className="modal-overlay"
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: "rgba(255, 105, 180, 0.8)",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        backdropFilter: "blur(5px)", // Blurred background
+        backgroundColor,
+      }}>
+      <div
+        className="modal usa-modal"
+        style={{
+          maxWidth: "600px",
+          margin: "100px auto",
+          background: "white",
+          padding: "20px",
+          borderRadius: "5px",
+        }}>
+        <div className="usa-modal__content">
+          <div className="usa-modal__main">{props.children}</div>
+          <Button
+            ariaLabel="Close this window"
+            size="tiny"
+            iconOnly={true}
+            icon={<Icons.Close />}
+            variation="unstyled"
+            className="usa-button usa-modal__close"
+            onClick={props.onClose}></Button>
         </div>
-        <Button
-          ariaLabel="Close this window"
-          size="tiny"
-          iconOnly={true}
-          icon={<Icons.Close />}
-          variation="unstyled"
-          className="usa-button usa-modal__close"></Button>
       </div>
     </div>
   );
+};
+
+export const ModalTitle = (props: ModalChildrenProps) => {
+  return <h2 className="modal-title usa-modal__heading">{props.children}</h2>;
+};
+
+export const ModalBody = (props: ModalChildrenProps) => {
+  return (
+    <div className="modal-body usa-prose">
+      <p>{props.children}</p>
+    </div>
+  );
+};
+
+export const ModalFooter = (props: ModalChildrenProps) => {
+  return <div className="modal-footer usa-modal__footer">{props.children}</div>;
 };

--- a/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.test.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.test.tsx
@@ -1,0 +1,10 @@
+import { render } from "@testing-library/react";
+import { ModalBody } from "./ModalBody";
+
+describe("ModalBody", () => {
+  it("should render text as a child", () => {
+    const child = "modal body content";
+    const { getByText } = render(<ModalBody>{child}</ModalBody>);
+    expect(getByText(child)).toBeInTheDocument();
+  });
+});

--- a/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.tsx
@@ -1,4 +1,4 @@
-export interface ModalChildrenProps {
+interface ModalChildrenProps {
   children: React.ReactNode;
 }
 

--- a/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalBody/ModalBody.tsx
@@ -1,0 +1,7 @@
+export interface ModalChildrenProps {
+  children: React.ReactNode;
+}
+
+export const ModalBody = (props: ModalChildrenProps) => {
+  return <div className="modal-body">{props.children}</div>;
+};

--- a/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.test.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { ModalFooter } from "./ModalFooter";
-import { Button } from "@us-gov-cdc/cdc-react";
+import { Button } from "../../Button/Button";
 
 describe("ModalFooter", () => {
   it("should render text as a child", () => {

--- a/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.test.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { ModalFooter } from "./ModalFooter";
+import { Button } from "@us-gov-cdc/cdc-react";
+
+describe("ModalFooter", () => {
+  it("should render text as a child", () => {
+    const child = "modal body content";
+    const { getByText } = render(<ModalFooter>{child}</ModalFooter>);
+    expect(getByText(child)).toBeInTheDocument();
+  });
+
+  it("should render a button as a child", () => {
+    const child = <Button ariaLabel="modal button" />;
+    const { container } = render(<ModalFooter>{child}</ModalFooter>);
+    expect(container.querySelector("button")).toBeInTheDocument();
+  });
+});

--- a/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -1,0 +1,6 @@
+export interface ModalChildrenProps {
+  children: React.ReactNode;
+}
+export const ModalFooter = (props: ModalChildrenProps) => {
+  return <div className="modal-footer usa-modal__footer">{props.children}</div>;
+};

--- a/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/packages/cdc-react/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -1,4 +1,4 @@
-export interface ModalChildrenProps {
+interface ModalChildrenProps {
   children: React.ReactNode;
 }
 export const ModalFooter = (props: ModalChildrenProps) => {

--- a/packages/cdc-react/src/components/index.ts
+++ b/packages/cdc-react/src/components/index.ts
@@ -9,5 +9,6 @@ export * from "./ProfileHeader/ProfileHeaderUserProfileMenuItem/ProfileHeaderUse
 export * from "./Button/Button";
 export * from "./Divider/Divider";
 export * from "./Card/Card";
+export * from "./Modal/Modal";
 
 export * from "../@types";

--- a/packages/cdc-react/src/components/index.ts
+++ b/packages/cdc-react/src/components/index.ts
@@ -10,5 +10,7 @@ export * from "./Button/Button";
 export * from "./Divider/Divider";
 export * from "./Card/Card";
 export * from "./Modal/Modal";
+export * from "./Modal/ModalBody/ModalBody";
+export * from "./Modal/ModalFooter/ModalFooter";
 
 export * from "../@types";

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -1,10 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
-// import { Modal } from "@us-gov-cdc/cdc-react";
-import { Modal } from "../../../cdc-react/src/components/Modal/Modal";
-import { ModalFooter } from "../../../cdc-react/src/components/Modal/ModalFooter/ModalFooter";
-import { ModalBody } from "../../../cdc-react/src/components/Modal/ModalBody/ModalBody";
-import { Button } from "@us-gov-cdc/cdc-react";
+import { Button, Modal, ModalBody, ModalFooter  } from "@us-gov-cdc/cdc-react";
 
 const meta: Meta<typeof Modal> = {
   title: "Components/Modal",

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -86,3 +86,65 @@ export const LockedBackground: Story = {
     );
   },
 };
+export const CDCExampleUSWDSStyles: Story = {
+  args: {
+    isOpen: false,
+    isForcedAction: true,
+  },
+  render: function Render(args) {
+    const [{ isOpen }, updateArgs] = useArgs();
+
+    function toggleModal() {
+      updateArgs({ isOpen: !isOpen });
+    }
+    return (
+      <>
+        <button onClick={toggleModal}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
+          <ModalTitle>You are about to leave the CDC website</ModalTitle>
+          <ModalBody>Links with this icon indicate that you are about to leave the CDC website.</ModalBody>
+          <ModalFooter>
+            <Button ariaLabel="continue" onClick={toggleModal}>
+              Continue without saving
+            </Button>
+            <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
+              Go back
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const CDCExample: Story = {
+  args: {
+    isOpen: false,
+    isForcedAction: true,
+  },
+  render: function Render(args) {
+    const [{ isOpen }, updateArgs] = useArgs();
+
+    function toggleModal() {
+      updateArgs({ isOpen: !isOpen });
+    }
+    return (
+      <>
+        <button onClick={toggleModal}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
+          <ModalTitle>You are about to leave the CDC website</ModalTitle>
+          <ModalBody>Links with this icon indicate that you are about to leave the CDC website.</ModalBody>
+          <ModalFooter>
+            <Button ariaLabel="continue" onClick={toggleModal}>
+              Continue without saving
+            </Button>
+            <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
+              Go back
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+  },
+};
+

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -13,7 +13,12 @@ const meta: Meta<typeof Modal> = {
   title: "Components/Modal",
   tags: ["autodocs"],
   component: Modal,
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: ["default", "lg"],
+      control: { type: "inline-radio" },
+    },
+  },
 };
 
 export default meta;

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -1,5 +1,13 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Modal } from "@us-gov-cdc/cdc-react";
+import { useArgs } from "@storybook/preview-api";
+// import { Modal } from "@us-gov-cdc/cdc-react";
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalTitle,
+} from "../../../cdc-react/src/components/Modal/Modal";
+import { Button } from "@us-gov-cdc/cdc-react";
 
 const meta: Meta<typeof Modal> = {
   title: "Components/Modal",
@@ -13,7 +21,39 @@ type Story = StoryObj<typeof Modal>;
 
 export const Example: Story = {
   args: {
-    modalTitle: "Are you sure you want to continue?",
-    modalBody: "You have unsaved changes that will be lost.",
+    isOpen: false,
+  },
+  render: function Render(args) {
+    const [{ isOpen }, updateArgs] = useArgs();
+
+    function handleOpenModal() {
+      updateArgs({ isOpen: !isOpen });
+    }
+
+    const handleCloseModal = () => {
+      updateArgs({ isOpen: !isOpen });
+      alert("Modal closed!");
+    };
+
+    return (
+      <>
+        <button onClick={handleOpenModal}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClose={handleCloseModal}>
+          <ModalTitle>Are you sure you want to continue?</ModalTitle>
+          <ModalBody>You have unsaved changes that will be lost.</ModalBody>
+          <ModalFooter>
+            <Button ariaLabel="continue" onClick={handleCloseModal}>
+              Continue without saving
+            </Button>
+            <Button
+              ariaLabel="go back"
+              variation="text"
+              onClick={handleCloseModal}>
+              Go back
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
   },
 };

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof Modal> = {
   component: Modal,
   argTypes: {
     size: {
-      options: ["default", "lg"],
+      options: ["default", "large"],
       control: { type: "inline-radio" },
     },
   },
@@ -143,8 +143,29 @@ export const CDCExample: Story = {
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>You are about to leave the CDC website</ModalTitle>
           <ModalBody>
-            Links with this icon indicate that you are about to leave the CDC
-            website.
+            <h6>
+              Links with this icon indicate that you are about to leave the CDC
+              website.
+            </h6>
+            <ul>
+              <li>
+                The Centers for Disease Control and Prevention (CDC) cannot
+                attest to the accuracy of a non-federal website.
+              </li>
+              <li>
+                Linking to a non-federal website does not constitute an
+                endorsement by CDC or any of its employees of the sponsors or
+                the information and products presented on the website.
+              </li>
+              <li>
+                You will be subject to the destination website’s privacy policy
+                when you follow the link.
+              </li>
+              <li>
+                CDC is not responsible for Section 508 compliance
+                (accessibility) on other federal or private websites.
+              </li>
+            </ul>
           </ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -23,6 +23,7 @@ export const Example: Story = {
   args: {
     isOpen: false,
     isForcedAction: false,
+    size: "default",
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
@@ -102,7 +103,10 @@ export const CDCExampleUSWDSStyles: Story = {
         <button onClick={toggleModal}>Open Modal</button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>You are about to leave the CDC website</ModalTitle>
-          <ModalBody>Links with this icon indicate that you are about to leave the CDC website.</ModalBody>
+          <ModalBody>
+            Links with this icon indicate that you are about to leave the CDC
+            website.
+          </ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>
               Continue without saving
@@ -133,13 +137,16 @@ export const CDCExample: Story = {
         <button onClick={toggleModal}>Open Modal</button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>You are about to leave the CDC website</ModalTitle>
-          <ModalBody>Links with this icon indicate that you are about to leave the CDC website.</ModalBody>
+          <ModalBody>
+            Links with this icon indicate that you are about to leave the CDC
+            website.
+          </ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>
-              Continue without saving
+              Action
             </Button>
             <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
-              Go back
+              Cancel
             </Button>
           </ModalFooter>
         </Modal>
@@ -147,4 +154,3 @@ export const CDCExample: Story = {
     );
   },
 };
-

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -13,12 +13,7 @@ const meta: Meta<typeof Modal> = {
   title: "Components/Modal",
   tags: ["autodocs"],
   component: Modal,
-  argTypes: {
-    size: {
-      options: ["default", "large"],
-      control: { type: "inline-radio" },
-    },
-  },
+  argTypes: {},
 };
 
 export default meta;
@@ -28,7 +23,6 @@ export const Example: Story = {
   args: {
     isOpen: false,
     isForcedAction: false,
-    size: "default",
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
@@ -36,11 +30,6 @@ export const Example: Story = {
     function toggleModal() {
       updateArgs({ isOpen: !isOpen });
     }
-
-    // const handleCloseModal = () => {
-    //   updateArgs({ isOpen: !isOpen });
-    //   alert("Modal closed!");
-    // };
 
     return (
       <>

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -11,4 +11,9 @@ const meta: Meta<typeof Modal> = {
 export default meta;
 type Story = StoryObj<typeof Modal>;
 
-export const Example: Story = {};
+export const Example: Story = {
+  args: {
+    modalTitle: "Are you sure you want to continue?",
+    modalBody: "You have unsaved changes that will be lost.",
+  },
+};

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -22,33 +22,62 @@ type Story = StoryObj<typeof Modal>;
 export const Example: Story = {
   args: {
     isOpen: false,
+    isForcedAction: false,
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
 
-    function handleOpenModal() {
+    function toggleModal() {
       updateArgs({ isOpen: !isOpen });
     }
 
-    const handleCloseModal = () => {
-      updateArgs({ isOpen: !isOpen });
-      alert("Modal closed!");
-    };
+    // const handleCloseModal = () => {
+    //   updateArgs({ isOpen: !isOpen });
+    //   alert("Modal closed!");
+    // };
 
     return (
       <>
-        <button onClick={handleOpenModal}>Open Modal</button>
-        <Modal {...args} isOpen={isOpen} onClose={handleCloseModal}>
+        <button onClick={toggleModal}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>Are you sure you want to continue?</ModalTitle>
           <ModalBody>You have unsaved changes that will be lost.</ModalBody>
           <ModalFooter>
-            <Button ariaLabel="continue" onClick={handleCloseModal}>
+            <Button ariaLabel="continue" onClick={toggleModal}>
               Continue without saving
             </Button>
-            <Button
-              ariaLabel="go back"
-              variation="text"
-              onClick={handleCloseModal}>
+            <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
+              Go back
+            </Button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const LockedBackground: Story = {
+  args: {
+    isOpen: false,
+    isForcedAction: true,
+  },
+  render: function Render(args) {
+    const [{ isOpen }, updateArgs] = useArgs();
+
+    function toggleModal() {
+      updateArgs({ isOpen: !isOpen });
+    }
+    return (
+      <>
+        <button onClick={toggleModal}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
+          <ModalTitle>Are you sure you want to continue?</ModalTitle>
+          <ModalBody>You have unsaved changes that will be lost.</ModalBody>
+          <ModalFooter>
+            <Button ariaLabel="continue" onClick={toggleModal}>
+              Continue without saving
+            </Button>
+            <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
               Go back
             </Button>
           </ModalFooter>

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -33,7 +33,9 @@ export const Example: Story = {
 
     return (
       <>
-        <button onClick={toggleModal}>Open Modal</button>
+        <Button ariaLabel="open modal" onClick={toggleModal}>
+          Open Modal
+        </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>Are you sure you want to continue?</ModalTitle>
           <ModalBody>You have unsaved changes that will be lost.</ModalBody>
@@ -64,43 +66,12 @@ export const LockedBackground: Story = {
     }
     return (
       <>
-        <button onClick={toggleModal}>Open Modal</button>
+        <Button ariaLabel="open modal" onClick={toggleModal}>
+          Open Modal
+        </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>Are you sure you want to continue?</ModalTitle>
           <ModalBody>You have unsaved changes that will be lost.</ModalBody>
-          <ModalFooter>
-            <Button ariaLabel="continue" onClick={toggleModal}>
-              Continue without saving
-            </Button>
-            <Button ariaLabel="go back" variation="text" onClick={toggleModal}>
-              Go back
-            </Button>
-          </ModalFooter>
-        </Modal>
-      </>
-    );
-  },
-};
-export const CDCExampleUSWDSStyles: Story = {
-  args: {
-    isOpen: false,
-    isForcedAction: true,
-  },
-  render: function Render(args) {
-    const [{ isOpen }, updateArgs] = useArgs();
-
-    function toggleModal() {
-      updateArgs({ isOpen: !isOpen });
-    }
-    return (
-      <>
-        <button onClick={toggleModal}>Open Modal</button>
-        <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
-          <ModalTitle>You are about to leave the CDC website</ModalTitle>
-          <ModalBody>
-            Links with this icon indicate that you are about to leave the CDC
-            website.
-          </ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>
               Continue without saving
@@ -128,7 +99,9 @@ export const CDCExample: Story = {
     }
     return (
       <>
-        <button onClick={toggleModal}>Open Modal</button>
+        <Button ariaLabel="open modal" onClick={toggleModal}>
+          Open Modal
+        </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
           <ModalTitle>You are about to leave the CDC website</ModalTitle>
           <ModalBody>

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Modal } from "@us-gov-cdc/cdc-react";
+
+const meta: Meta<typeof Modal> = {
+  title: "Components/Modal",
+  tags: ["autodocs"],
+  component: Modal,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+export const Example: Story = {};

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -5,7 +5,6 @@ import {
   Modal,
   ModalBody,
   ModalFooter,
-  ModalTitle,
 } from "../../../cdc-react/src/components/Modal/Modal";
 import { Button } from "@us-gov-cdc/cdc-react";
 
@@ -23,6 +22,7 @@ export const Example: Story = {
   args: {
     isOpen: false,
     isForcedAction: false,
+    modalTitle: "Are you sure you want to continue?",
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
@@ -37,7 +37,6 @@ export const Example: Story = {
           Open Modal
         </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
-          <ModalTitle>Are you sure you want to continue?</ModalTitle>
           <ModalBody>You have unsaved changes that will be lost.</ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>
@@ -57,6 +56,7 @@ export const LockedBackground: Story = {
   args: {
     isOpen: false,
     isForcedAction: true,
+    modalTitle: "Are you sure you want to continue?",
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
@@ -70,7 +70,6 @@ export const LockedBackground: Story = {
           Open Modal
         </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
-          <ModalTitle>Are you sure you want to continue?</ModalTitle>
           <ModalBody>You have unsaved changes that will be lost.</ModalBody>
           <ModalFooter>
             <Button ariaLabel="continue" onClick={toggleModal}>
@@ -90,6 +89,7 @@ export const CDCExample: Story = {
   args: {
     isOpen: false,
     isForcedAction: true,
+    modalTitle: "Are you sure you want to continue?",
   },
   render: function Render(args) {
     const [{ isOpen }, updateArgs] = useArgs();
@@ -103,7 +103,6 @@ export const CDCExample: Story = {
           Open Modal
         </Button>
         <Modal {...args} isOpen={isOpen} onClose={toggleModal}>
-          <ModalTitle>You are about to leave the CDC website</ModalTitle>
           <ModalBody>
             <h6>
               Links with this icon indicate that you are about to leave the CDC

--- a/packages/storybook/src/stories/Modal.stories.tsx
+++ b/packages/storybook/src/stories/Modal.stories.tsx
@@ -1,11 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
 // import { Modal } from "@us-gov-cdc/cdc-react";
-import {
-  Modal,
-  ModalBody,
-  ModalFooter,
-} from "../../../cdc-react/src/components/Modal/Modal";
+import { Modal } from "../../../cdc-react/src/components/Modal/Modal";
+import { ModalFooter } from "../../../cdc-react/src/components/Modal/ModalFooter/ModalFooter";
+import { ModalBody } from "../../../cdc-react/src/components/Modal/ModalBody/ModalBody";
 import { Button } from "@us-gov-cdc/cdc-react";
 
 const meta: Meta<typeof Modal> = {


### PR DESCRIPTION
This PR introduces a new modal component to our cdc-react component library.

---
The modal component displays content with potential action buttons above the main page content. The modal can be closed through 1) an X button that is present in every modal or 2) clicking on the gray overlay around the modal (unless this feature is disabled by the developer).


#### Future improvements and features include:
- Tab focusing/trapping for accessibility