### PR TITLE
Portal 1122/update cdc colors

### DIFF
--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -36,7 +36,7 @@ $secondary-slate: #7e9ba5;
 $secondary-teal: #4ebaaa;
 
 $tertiary-amber: #ffecb3;
-$tertiary-blue: #a7e0ff;
+$tertiary-blue: #c0e9ff;
 $tertiary-brown: #d7ccc8;
 $tertiary-cyan: #cce5e9;
 $tertiary-green: #dcedc8;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -24,7 +24,7 @@ $primary-slate: #29434e;
 $primary-teal: #00695c;
 
 $secondary-blue: #88c3ea;
-$secondary-amber: #ffecb3;
+$secondary-amber: #ffd54f;
 $secondary-brown: #ad907b;
 $secondary-cyan: #65b0bd;
 $secondary-green: #84bc49;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -11,31 +11,53 @@ $gray-darker: #333333;
 $gray-light: #e0e0e0;
 $gray-lighter: #f0f0f0;
 
-$primary-blue: #015fa9; // Figma is #015fa9
-$primary-amber: #fbab19; // Figma is #fbab19
+$primary-blue: #005eaa;
+$primary-amber: #fbab18;
 $primary-brown: #705043;
-$primary-cyan: #027b91; // Figma is #027b91
+$primary-cyan: #006778;
 $primary-green: #497d0c;
 $primary-indigo: #26418f;
 $primary-orange: #bb4d00;
 $primary-pink: #af4448;
 $primary-purple: #712177;
 $primary-slate: #29434e;
-$primary-teal: #01695c; // Figma is #01695c
+$primary-teal: #00695c;
 
-$secondary-blue: #196eb3;
+$secondary-blue: #88c3ea;
+$secondary-amber: #ffecb3;
+$secondary-brown: #ad907b;
+$secondary-cyan: #65b0bd;
+$secondary-green: #84bc49;
+$secondary-indigo: #92a6dd;
+$secondary-orange: #ffad42;
+$secondary-pink: #e57373;
+$secondary-purple: #b890bb;
+$secondary-slate: #7e9ba5;
+$secondary-teal: #4ebaaa;
 
-$tertiary-amber: #ffecb3;
-$tertiary-blue: #c0e9ff;
-$tertiary-brown: #decec6; // Figma is #decdc6
+$tertiary-amber: #fff7e1;
+$tertiary-blue: #a7e0ff;
+$tertiary-brown: #decec6;
 $tertiary-cyan: #cce5e9;
 $tertiary-green: #dcedc8;
 $tertiary-indigo: #dee8ff;
 $tertiary-orange: #ffe97d;
 $tertiary-pink: #ffc2c2;
 $tertiary-purple: #e3d3e4;
-$tertiary-slate: #b6c6d2; // Figma is #b6c5d2
+$tertiary-slate: #b6c6d2;
 $tertiary-teal: #ceece7;
+
+$quaternary-amber: #fff7e1;
+$quaternary-blue: #edf9ff;
+$quaternary-brown: #f2ebe8;
+$quaternary-cyan: #ebf5f6;
+$quaternary-green: #f1f8e9;
+$quaternary-indigo: #f2f6ff;
+$quaternary-orange: #fff4cf;
+$quaternary-pink: #ffe7e7;
+$quaternary-purple: #f7f2f7;
+$quaternary-slate: #e2e8ed;
+$quaternary-teal: #ebf7f5;
 
 $success: #f1f8e9;
 $success-dark: #497d0c;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -11,30 +11,30 @@ $gray-darker: #333333;
 $gray-light: #e0e0e0;
 $gray-lighter: #f0f0f0;
 
-$primary-blue: #005eaa;
-$primary-amber: #ffecb3; // TODO: get accurate color.
+$primary-blue: #015fa9; // Figma is #015fa9
+$primary-amber: #fbab19; // Figma is #fbab19
 $primary-brown: #705043;
-$primary-cyan: #007b91;
+$primary-cyan: #027b91; // Figma is #027b91
 $primary-green: #497d0c;
 $primary-indigo: #26418f;
 $primary-orange: #bb4d00;
 $primary-pink: #af4448;
 $primary-purple: #712177;
 $primary-slate: #29434e;
-$primary-teal: #00695c;
+$primary-teal: #01695c; // Figma is #01695c
 
 $secondary-blue: #196eb3;
 
 $tertiary-amber: #ffecb3;
 $tertiary-blue: #c0e9ff;
-$tertiary-brown: #decec6;
+$tertiary-brown: #decec6; // Figma is #decdc6
 $tertiary-cyan: #cce5e9;
 $tertiary-green: #dcedc8;
 $tertiary-indigo: #dee8ff;
 $tertiary-orange: #ffe97d;
 $tertiary-pink: #ffc2c2;
 $tertiary-purple: #e3d3e4;
-$tertiary-slate: #b6c6d2;
+$tertiary-slate: #b6c6d2; // Figma is #b6c5d2
 $tertiary-teal: #ceece7;
 
 $success: #f1f8e9;
@@ -43,6 +43,7 @@ $error: #ffe7e7;
 $error-dark: #af4448;
 $warning: #fff4cf;
 $warning-dark: #bb4d00;
+$warning-dark-alt: #fbab18;
 $info: #f5f5f5;
 $info-dark: #555555;
 $busy: #edf9ff;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -37,7 +37,7 @@ $secondary-teal: #4ebaaa;
 
 $tertiary-amber: #fff7e1;
 $tertiary-blue: #a7e0ff;
-$tertiary-brown: #decec6;
+$tertiary-brown: #d7ccc8;
 $tertiary-cyan: #cce5e9;
 $tertiary-green: #dcedc8;
 $tertiary-indigo: #dee8ff;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -1,21 +1,3 @@
-$main-theme: #005eaa;
-$main-theme-dark: #004f8f;
-$main-theme-darker: #004175;
-$main-theme-light: #88c3ea;
-$main-theme-lighter: #c0e9ff;
-
-$success: #f1f8e9;
-$success-dark: #497d0c;
-$error: #ffe7e7;
-$error-dark: #af4448;
-$warning: #fff4cf;
-$warning-dark: #bb4d00;
-$warning-dark-alt: #fbab18;
-$info: #f5f5f5;
-$info-dark: #555555;
-$busy: #edf9ff;
-$busy-dark: #005eaa;
-
 /* These colors are sourced from the CDC WCMS - Color Explorer & Preferred Pairings:
  * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/theme-explorer.html
  * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/preferred-color-pairings.html
@@ -23,6 +5,7 @@ $busy-dark: #005eaa;
  * a primary, secondary, tertiary, and quaternary. Review the CDC WCMS TP4 site 
  * for guidance on usage and 508 accessibility.
  */
+
 $primary-amber: #fbab18;
 $primary-blue: #005eaa;
 $primary-brown: #705043;
@@ -77,3 +60,21 @@ $gray-light: #e0e0e0;
 $gray-standard: #bdbdbd;
 $gray-dark: #555555;
 $gray-darker: #333333;
+
+$main-theme: $primary-blue;
+$main-theme-dark: #004f8f; // Todo: map this to CDC WCMS
+$main-theme-darker: #004175; // Todo: map this to CDC WCMS
+$main-theme-light: $secondary-blue;
+$main-theme-lighter: $tertiary-blue;
+
+$success: $quaternary-green;
+$success-dark: $primary-green;
+$error: $quaternary-pink;
+$error-dark: $primary-pink;
+$warning: $tertiary-amber;
+$warning-dark: $primary-orange; // Todo: this should be refactored to $primary-amber
+$warning-dark-alt: $primary-amber;
+$info: $gray-lightest;
+$info-dark: $gray-dark;
+$busy: $quaternary-blue;
+$busy-dark: $primary-blue;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -35,7 +35,7 @@ $secondary-purple: #b890bb;
 $secondary-slate: #7e9ba5;
 $secondary-teal: #4ebaaa;
 
-$tertiary-amber: #fff7e1;
+$tertiary-amber: #ffecb3;
 $tertiary-blue: #a7e0ff;
 $tertiary-brown: #d7ccc8;
 $tertiary-cyan: #cce5e9;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -1,20 +1,32 @@
-/* Accessibility Color Variables */
-
 $main-theme: #005eaa;
 $main-theme-dark: #004f8f;
 $main-theme-darker: #004175;
 $main-theme-light: #88c3ea;
 $main-theme-lighter: #c0e9ff;
 
-$gray-dark: #555555;
-$gray-darker: #333333;
-$gray-light: #e0e0e0;
-$gray-lighter: #f0f0f0;
+$success: #f1f8e9;
+$success-dark: #497d0c;
+$error: #ffe7e7;
+$error-dark: #af4448;
+$warning: #fff4cf;
+$warning-dark: #bb4d00;
+$warning-dark-alt: #fbab18;
+$info: #f5f5f5;
+$info-dark: #555555;
+$busy: #edf9ff;
+$busy-dark: #005eaa;
 
-$primary-blue: #005eaa;
+/* These colors are sourced from the CDC WCMS - Color Explorer & Preferred Pairings:
+ * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/theme-explorer.html
+ * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/preferred-color-pairings.html
+ * There are 10 main theme colors, and 11 accent colors. For each color there is
+ * a primary, secondary, tertiary, and quaternary. Review the CDC WCMS TP4 site 
+ * for guidance on usage and 508 accessibility.
+ */
 $primary-amber: #fbab18;
+$primary-blue: #005eaa;
 $primary-brown: #705043;
-$primary-cyan: #006778;
+$primary-cyan: #007b91;
 $primary-green: #497d0c;
 $primary-indigo: #26418f;
 $primary-orange: #bb4d00;
@@ -23,8 +35,8 @@ $primary-purple: #712177;
 $primary-slate: #29434e;
 $primary-teal: #00695c;
 
-$secondary-blue: #88c3ea;
 $secondary-amber: #ffd54f;
+$secondary-blue: #88c3ea;
 $secondary-brown: #ad907b;
 $secondary-cyan: #65b0bd;
 $secondary-green: #84bc49;
@@ -37,7 +49,7 @@ $secondary-teal: #4ebaaa;
 
 $tertiary-amber: #ffecb3;
 $tertiary-blue: #c0e9ff;
-$tertiary-brown: #d7ccc8;
+$tertiary-brown: #decec6;
 $tertiary-cyan: #cce5e9;
 $tertiary-green: #dcedc8;
 $tertiary-indigo: #dee8ff;
@@ -59,14 +71,9 @@ $quaternary-purple: #f7f2f7;
 $quaternary-slate: #e2e8ed;
 $quaternary-teal: #ebf7f5;
 
-$success: #f1f8e9;
-$success-dark: #497d0c;
-$error: #ffe7e7;
-$error-dark: #af4448;
-$warning: #fff4cf;
-$warning-dark: #bb4d00;
-$warning-dark-alt: #fbab18;
-$info: #f5f5f5;
-$info-dark: #555555;
-$busy: #edf9ff;
-$busy-dark: #005eaa;
+$gray-lightest: #f5f5f5;
+$gray-lighter: #f0f0f0;
+$gray-light: #e0e0e0;
+$gray-standard: #bdbdbd;
+$gray-dark: #555555;
+$gray-darker: #333333;

--- a/packages/cdc-react/src/scss/_colors.scss
+++ b/packages/cdc-react/src/scss/_colors.scss
@@ -19,7 +19,7 @@ $busy-dark: #005eaa;
 /* These colors are sourced from the CDC WCMS - Color Explorer & Preferred Pairings:
  * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/theme-explorer.html
  * https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/preferred-color-pairings.html
- * There are 10 main theme colors, and 11 accent colors. For each color there is
+ * There are 11 colors total between main and accents. For each color there is
  * a primary, secondary, tertiary, and quaternary. Review the CDC WCMS TP4 site 
  * for guidance on usage and 508 accessibility.
  */


### PR DESCRIPTION
Updates color variables to align with CDC WCMS.

Notes
* Colors sourced from: https://www.cdc.gov/wcms/4.0/cdc-wp/page-and-site-options/preferred-color-pairings.html
* I'm unsure where `$main-theme-dark` and `$main-theme-darker` are sourced from. I added a note in the code to revisit this.
* The state colors (warning, error, etc...) are updated to use the existing color variables now.
* `$warning-dark` is currently mapped to `$primary-orange;` which I believe is incorrect and it should be mapped to `$primary-amber`. I added a note to refactor this in a future update