### PR TITLE
feat: bespoke Dropdown onSelect class

### DIFF
--- a/packages/cdc-react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/cdc-react/src/components/Checkbox/Checkbox.test.tsx
@@ -1,34 +1,33 @@
 import { render } from "@testing-library/react";
-import { describe, test } from "vitest";
+import { describe, test, expect } from "vitest";
 import { Checkbox } from "./Checkbox";
 
-describe("Checkbox Component", () => {
-  test("should render checkbox component with default state", () => {
-    const { getByLabelText } = render(
-      <Checkbox label="checkbox" isChecked={false} />
+describe("Checkbox Component with Icons", () => {
+  test("displays a check icon when checked", () => {
+    const { getByTitle } = render(
+      <Checkbox label="Checked Checkbox" isChecked={true} />
     );
-    const checkbox = getByLabelText("checkbox") as HTMLInputElement;
-
-    expect(checkbox.checked).toBe(false);
-    expect(checkbox.indeterminate).toBe(false);
+    const checkIcon = getByTitle("check-icon");
+    expect(checkIcon).toBeInTheDocument();
   });
 
-  test("should render checkbox component with checked state", () => {
-    const { getByLabelText } = render(
-      <Checkbox label="checkbox" isChecked={true} />
+  test("displays a minus icon when indeterminate", () => {
+    const { getByTitle } = render(
+      <Checkbox
+        label="Indeterminate Checkbox"
+        isChecked={false}
+        indeterminate={true}
+      />
     );
-    const checkbox = getByLabelText("checkbox") as HTMLInputElement;
-
-    expect(checkbox.checked).toBe(true);
+    const minusIcon = getByTitle("minus-icon");
+    expect(minusIcon).toBeInTheDocument();
   });
 
-  test("should render checkbox component with indeterminate state", () => {
-    const { getByLabelText } = render(
-      <Checkbox label="checkbox" isChecked={false} indeterminate={true} />
+  test("does not display any icon when unchecked and not indeterminate", () => {
+    const { queryByTitle } = render(
+      <Checkbox label="Unchecked Checkbox" isChecked={false} />
     );
-    const checkbox = getByLabelText("checkbox") as HTMLInputElement;
-
-    expect(checkbox.indeterminate).toBe(true);
-    expect(checkbox.checked).toBe(false);
+    const icon = queryByTitle("check-icon") || queryByTitle("minus-icon");
+    expect(icon).not.toBeInTheDocument();
   });
 });

--- a/packages/cdc-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/cdc-react/src/components/Dropdown/Dropdown.scss
@@ -16,10 +16,11 @@
     span {
       display: flex;
       color: global.$gray-darker;
+      margin: units("05") 0 units("05") 0;
 
       &.dropdown-label-icon {
         flex-grow: 0.05;
-        padding: units("05");
+        padding: 0 units("05") 0 units("05");
       }
 
       &.dropdown-label {

--- a/packages/cdc-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/cdc-react/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ export interface DropdownProps {
     | React.KeyboardEventHandler<HTMLDivElement>
     | undefined;
   id?: string;
+  className?: string;
 }
 
 /**
@@ -31,7 +32,7 @@ export const Dropdown = ({
   onKeyDownDropdownItems,
   id,
   className,
-}: DropdownProps & JSX.IntrinsicElements["div"]) => {
+}: DropdownProps) => {
   const [dropdownOpen, setDropdownVisibility] = useState(false);
   const [dropdownCurrentItem, setDropdownCurrentItem] = useState(label);
 

--- a/packages/storybook/src/stories/Dropdown.stories.tsx
+++ b/packages/storybook/src/stories/Dropdown.stories.tsx
@@ -25,3 +25,14 @@ export const Example: Story = {
     },
   },
 };
+
+export const NoIcon: Story = {
+  args: {
+    srText: "Dropdown Screen Reader text",
+    label: "Dropdown Label",
+    items: ["Item One", "Item Two", "Item Three"],
+    onSelect: (item: string) => {
+      console.log(item);
+    },
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8080,16 +8080,7 @@ string-argv@~0.3.1:
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8163,14 +8154,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8961,16 +8945,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
I needed to remove the `JSX.IntrinsicElements` from the props to allow the `onSelect` to be bespoke to the cdc-react drop down. Before the default div onSelect was overwriting the Dropdowns `onSelect`. 